### PR TITLE
Improve token verification flow

### DIFF
--- a/src/PetToys.CloudflareTurnstileNet/ITurnstileService.cs
+++ b/src/PetToys.CloudflareTurnstileNet/ITurnstileService.cs
@@ -1,9 +1,10 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PetToys.CloudflareTurnstileNet;
 
 public interface ITurnstileService
 {
-    Task<bool> VerifyAsync(string token, IPAddress? remoteIp = null, bool useIdempotencyKey = false);
+    Task<bool> VerifyAsync(string token, IPAddress? remoteIp = null, bool useIdempotencyKey = false, CancellationToken cancellationToken = default);
 }

--- a/src/PetToys.CloudflareTurnstileNet/TurnstileService.cs
+++ b/src/PetToys.CloudflareTurnstileNet/TurnstileService.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Json;
 using System.Net.Mime;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 
@@ -23,8 +24,10 @@ internal sealed class TurnstileService(
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
-    public async Task<bool> VerifyAsync(string token, IPAddress? remoteIp = null, bool useIdempotencyKey = false)
+    public async Task<bool> VerifyAsync(string token, IPAddress? remoteIp = null, bool useIdempotencyKey = false, CancellationToken cancellationToken = default)
     {
+        if (string.IsNullOrWhiteSpace(token)) return false;
+
         var message = new HttpRequestMessage()
         {
             Method = HttpMethod.Post,
@@ -40,10 +43,10 @@ internal sealed class TurnstileService(
                 JsonOptions),
         };
 
-        var response = await client.SendAsync(message);
+        var response = await client.SendAsync(message, cancellationToken);
         if (!response.IsSuccessStatusCode) return false;
 
-        var json = await response.Content.ReadAsStringAsync();
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
 
         var result = JsonSerializer.Deserialize<ValidationResponse>(json);
         return result?.Success == true;

--- a/src/PetToys.CloudflareTurnstileNet/ValidateTurnstileFilter.cs
+++ b/src/PetToys.CloudflareTurnstileNet/ValidateTurnstileFilter.cs
@@ -79,13 +79,14 @@ internal sealed class ValidateTurnstileFilter(
                 !await service.VerifyAsync(
                     token.ToString(),
                     useRemoteIp ? context.HttpContext.Connection.RemoteIpAddress : null,
-                    useIdempotencyKey))
+                    useIdempotencyKey,
+                    context.HttpContext.RequestAborted))
             {
                 context.ModelState.AddModelError(string.Empty, GetErrorMessage(context, formErrorMessage));
 
                 if (fieldErrorMessage is not null)
                 {
-                    context.ModelState.AddModelError(string.Empty, GetErrorMessage(context, fieldErrorMessage));
+                    context.ModelState.AddModelError(formField, GetErrorMessage(context, fieldErrorMessage));
                 }
             }
         }

--- a/test/PetToys.CloudflareTurnstileNet.Tests/TurnstileServiceTest.cs
+++ b/test/PetToys.CloudflareTurnstileNet.Tests/TurnstileServiceTest.cs
@@ -1,4 +1,7 @@
-﻿using System.Net;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -6,10 +9,10 @@ using Xunit;
 
 namespace PetToys.CloudflareTurnstileNet.Tests;
 
-[Trait("Category", "Integration")]
 public sealed class TurnstileServiceTest
 {
     [Theory]
+    [Trait("Category", "Integration")]
     [InlineData(SecretKeys.AlwaysPasses, true)]
     [InlineData(SecretKeys.AlwaysFails, false)]
     [InlineData(SecretKeys.TokenAlreadySpent, false)]
@@ -18,9 +21,54 @@ public sealed class TurnstileServiceTest
         var provider = CreateProvider(string.Empty, secretKey);
         var sut = provider.GetRequiredService<ITurnstileService>();
 
-        var result = await sut.VerifyAsync("token", IPAddress.Loopback, true);
+        var result = await sut.VerifyAsync("token", IPAddress.Loopback, true, TestContext.Current.CancellationToken);
 
         result.Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t\r\n")]
+    public async Task VerifyAsync_EmptyToken_ReturnsFalseWithoutCallingCloudflare(string? token)
+    {
+        var handler = new RecordingHandler();
+        var provider = CreateProvider(handler);
+        var sut = provider.GetRequiredService<ITurnstileService>();
+
+        var result = await sut.VerifyAsync(token!, cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Should().BeFalse();
+        handler.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_NonEmptyToken_CallsCloudflare()
+    {
+        var handler = new RecordingHandler("""{"success":true}""");
+        var provider = CreateProvider(handler);
+        var sut = provider.GetRequiredService<ITurnstileService>();
+
+        var result = await sut.VerifyAsync("token", cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Should().BeTrue();
+        handler.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_PropagatesCancellationToken()
+    {
+        var handler = new RecordingHandler();
+        var provider = CreateProvider(handler);
+        var sut = provider.GetRequiredService<ITurnstileService>();
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = async () => await sut.VerifyAsync("token", cancellationToken: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
     private static ServiceProvider CreateProvider(string siteKey, string secretKey)
@@ -33,5 +81,35 @@ public sealed class TurnstileServiceTest
         });
 
         return services.BuildServiceProvider();
+    }
+
+    private static ServiceProvider CreateProvider(HttpMessageHandler handler)
+    {
+        var services = new ServiceCollection();
+        services.AddCloudflareTurnstile(
+            opt =>
+            {
+                opt.SiteKey = string.Empty;
+                opt.SecretKey = SecretKeys.AlwaysPasses;
+            },
+            builder => builder.ConfigurePrimaryHttpMessageHandler(() => handler));
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class RecordingHandler(string responseJson = """{"success":false}""") : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseJson),
+            };
+        }
     }
 }

--- a/test/PetToys.CloudflareTurnstileNet.Tests/ValidateTurnstileFilterTest.cs
+++ b/test/PetToys.CloudflareTurnstileNet.Tests/ValidateTurnstileFilterTest.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Xunit;
+
+namespace PetToys.CloudflareTurnstileNet.Tests;
+
+public sealed class ValidateTurnstileFilterTest
+{
+    private const string FormField = "cf-turnstile-response";
+    private const string FormErrorMessage = "form-error";
+    private const string FieldErrorMessage = "field-error";
+
+    [Fact]
+    public async Task OnActionExecution_VerificationFails_AddsFieldErrorUnderFormFieldKey()
+    {
+        var service = new Mock<ITurnstileService>();
+        service
+            .Setup(s => s.VerifyAsync(It.IsAny<string>(), It.IsAny<IPAddress?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var filter = new ValidateTurnstileFilter(service.Object, FormField, FormErrorMessage, FieldErrorMessage, false, false);
+        var context = CreateActionExecutingContext(token: "bad-token");
+
+        await filter.OnActionExecutionAsync(context, () => Task.FromResult(
+            new ActionExecutedContext(context, context.Filters, controller: null!)));
+
+        context.ModelState[FormField]!.Errors.Select(e => e.ErrorMessage).Should().Contain(FieldErrorMessage);
+        context.ModelState[string.Empty]!.Errors.Select(e => e.ErrorMessage).Should().Contain(FormErrorMessage);
+        context.ModelState[string.Empty]!.Errors.Select(e => e.ErrorMessage).Should().NotContain(FieldErrorMessage);
+    }
+
+    [Fact]
+    public async Task OnActionExecution_VerificationSucceeds_AddsNoErrors()
+    {
+        var service = new Mock<ITurnstileService>();
+        service
+            .Setup(s => s.VerifyAsync(It.IsAny<string>(), It.IsAny<IPAddress?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var filter = new ValidateTurnstileFilter(service.Object, FormField, FormErrorMessage, FieldErrorMessage, false, false);
+        var context = CreateActionExecutingContext(token: "good-token");
+
+        await filter.OnActionExecutionAsync(context, () => Task.FromResult(
+            new ActionExecutedContext(context, context.Filters, controller: null!)));
+
+        context.ModelState.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OnActionExecution_PassesRequestAbortedToService()
+    {
+        using var cts = new CancellationTokenSource();
+        var service = new Mock<ITurnstileService>();
+        service
+            .Setup(s => s.VerifyAsync(It.IsAny<string>(), It.IsAny<IPAddress?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var filter = new ValidateTurnstileFilter(service.Object, FormField, FormErrorMessage, FieldErrorMessage, false, false);
+        var context = CreateActionExecutingContext(token: "good-token");
+        context.HttpContext.RequestAborted = cts.Token;
+
+        await filter.OnActionExecutionAsync(context, () => Task.FromResult(
+            new ActionExecutedContext(context, context.Filters, controller: null!)));
+
+        service.Verify(
+            s => s.VerifyAsync(It.IsAny<string>(), It.IsAny<IPAddress?>(), It.IsAny<bool>(), cts.Token),
+            Times.Once);
+    }
+
+    private static ActionExecutingContext CreateActionExecutingContext(string token)
+    {
+        var services = new ServiceCollection();
+        services.Configure<CloudflareTurnstileOptions>(opt => opt.Enabled = true);
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+        };
+        httpContext.Request.ContentType = "application/x-www-form-urlencoded";
+        httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
+        {
+            [FormField] = token,
+        });
+
+        var actionContext = new Microsoft.AspNetCore.Mvc.ActionContext(
+            httpContext,
+            new RouteData(),
+            new ActionDescriptor(),
+            new ModelStateDictionary());
+
+        return new ActionExecutingContext(
+            actionContext,
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object?>(),
+            controller: null!);
+    }
+}


### PR DESCRIPTION
- Add optional CancellationToken to ITurnstileService.VerifyAsync and flow it through the HTTP send and content read; pass RequestAborted from the validation filter.
- Short-circuit VerifyAsync to false for null/empty/whitespace tokens without contacting the Cloudflare endpoint.
- Attach the field error message to the form field model-state key instead of the empty key so field-level validation helpers render it.
- Cover the new behavior with handler-backed and filter unit tests.

refs #3
refs #4
refs #5

