### PR TITLE
ci: align build and release pipelines with release-notes handling

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,4 +1,4 @@
-name: build-deplpy
+name: build-deploy
 
 on:
   release:
@@ -16,31 +16,39 @@ env:
   DevRepositoryUrl: "https://github.com/pet-toys/cloudflare-turnstile-net/pkgs/nuget/PetToys.CloudflareTurnstileNet"
   ProdRepositoryUrl: "https://www.nuget.org/packages/PetToys.CloudflareTurnstileNet"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
 jobs:
   test:
     name: test
     uses: ./.github/workflows/test.yml
- 
+
   build:
     needs: test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: |
       startsWith(github.event.release.tag_name, 'v')
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         global-json-file: global.json
 
     - name: Version
-      run: echo "PACKAGE_VERSION=$(echo ${{ github.event.release.tag_name }} | cut -c 2-)" >> $GITHUB_ENV
-
-    - name: Release notes
-      run: echo "${{ github.event.release.body }}" > assets/RELEASE-NOTES.txt
+      env:
+        TAG_NAME: ${{ github.event.release.tag_name }}
+      run: echo "PACKAGE_VERSION=${TAG_NAME#v}" >> "$GITHUB_ENV"
 
     - name: Restore
       run: dotnet restore ${{ env.ProjectsToPack }}
@@ -51,8 +59,16 @@ jobs:
     - name: Pack
       run: dotnet pack ${{ env.ProjectsToPack }} --configuration Release  --no-build --include-symbols --output ${{ github.workspace }}/${{ env.PackagesSubfolder }} -p:PackageVersion=${{ env.PACKAGE_VERSION }}
 
+    - name: Sync release notes to the GitHub release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG_NAME: ${{ github.event.release.tag_name }}
+      run: |
+        dotnet msbuild ${{ env.ProjectsToPack }} --target:ExportPackageReleaseNotes -p:ReleaseNotesExportPath="${{ runner.temp }}/release-notes.txt"
+        gh release edit "$TAG_NAME" --notes-file "${{ runner.temp }}/release-notes.txt"
+
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ env.ArtifactName }}
         if-no-files-found: error
@@ -64,8 +80,8 @@ jobs:
 
   deploy-github:
     needs: build
-    runs-on: ubuntu-22.04
-    environment: 
+    runs-on: ubuntu-latest
+    environment:
       name: development
       url: ${{ env.DevRepositoryUrl }}
     if: |
@@ -76,24 +92,26 @@ jobs:
 
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ env.ArtifactName }}
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         global-json-file: global.json
 
     - name: Push to github
       working-directory: ${{ env.PackagesSubfolder }}
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        dotnet nuget push "*.nupkg" -k ${{ secrets.GITHUB_TOKEN }} -s ${{ env.GitHubPackageSource }} --skip-duplicate
- 
+        dotnet nuget push "*.nupkg" -k "$NUGET_AUTH_TOKEN" -s ${{ env.GitHubPackageSource }} --skip-duplicate
+
   deploy-nuget:
     needs: build
-    runs-on: ubuntu-22.04
-    environment: 
+    runs-on: ubuntu-latest
+    environment:
       name: production
       url: ${{ env.ProdRepositoryUrl }}
     if: |
@@ -102,16 +120,18 @@ jobs:
 
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ env.ArtifactName }}
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         global-json-file: global.json
 
     - name: Push to nuget.org
       working-directory: ${{ env.PackagesSubfolder }}
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       run: |
-        dotnet nuget push "*.nupkg" -k ${{ secrets.NUGET_API_KEY }} -s ${{ env.NuGetOrgPackageSource }} --skip-duplicate
+        dotnet nuget push "*.nupkg" -k "$NUGET_API_KEY" -s ${{ env.NuGetOrgPackageSource }} --skip-duplicate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,13 @@ on:
     branches:
     - dev
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: test-${{ matrix.os }}
@@ -19,20 +26,16 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu-22.04
+        - ubuntu-latest
         - windows-latest
         - macos-latest
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        global-json-file: global.json
-
-    - uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         global-json-file: global.json
 

--- a/src/PetToys.CloudflareTurnstileNet/PetToys.CloudflareTurnstileNet.csproj
+++ b/src/PetToys.CloudflareTurnstileNet/PetToys.CloudflareTurnstileNet.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworkVersions)</TargetFrameworks>
-    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet package">
@@ -20,13 +19,33 @@
     <None Include="..\..\README.md" Pack="true" Visible="false" PackagePath="/" />
   </ItemGroup>
 
-  <Target Name="PreparePackageReleaseNotesFromFile" BeforeTargets="GenerateNuspec">
-    <ReadLinesFromFile File="..\..\assets\RELEASE-NOTES.txt">
-      <Output TaskParameter="Lines" ItemName="ReleaseNoteLines" />
-    </ReadLinesFromFile>
+  <PropertyGroup>
+    <ReleaseNotesFile>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', '..', 'assets', 'RELEASE-NOTES.txt'))</ReleaseNotesFile>
+    <!-- RELEASE-NOTES.txt is a cumulative changelog, newest version on top,
+         versions separated by a line of 3+ hyphens. Publish only the top
+         section. Read verbatim (not ReadLinesFromFile, which drops blank lines
+         and strips the indentation of wrapped bullets). -->
+    <ReleaseNotesSeparatorPattern>(?s)\A.*?(?=\r?\n[ \t]*-{3,}[ \t]*\r?\n|\z)</ReleaseNotesSeparatorPattern>
+    <!-- Leading version header (version line + '=' underline + blank lines).
+         Stripped from the published notes; it lives only in RELEASE-NOTES.txt
+         (NuGet and the GitHub release already show the version). -->
+    <ReleaseNotesHeaderPattern>\A[^\r\n]*\r?\n=+[ \t]*\r?\n\s*</ReleaseNotesHeaderPattern>
+  </PropertyGroup>
+
+  <Target Name="PreparePackageReleaseNotesFromFile" BeforeTargets="GenerateNuspec"
+          Condition="Exists('$(ReleaseNotesFile)')">
     <PropertyGroup>
-      <PackageReleaseNotes>@(ReleaseNoteLines, '%0a')</PackageReleaseNotes>
+      <_ReleaseNotesTopSection>$([System.Text.RegularExpressions.Regex]::Match($([System.IO.File]::ReadAllText('$(ReleaseNotesFile)')), '$(ReleaseNotesSeparatorPattern)').Value)</_ReleaseNotesTopSection>
+      <PackageReleaseNotes>$([System.Text.RegularExpressions.Regex]::Replace($(_ReleaseNotesTopSection), '$(ReleaseNotesHeaderPattern)', '').TrimEnd())</PackageReleaseNotes>
     </PropertyGroup>
+  </Target>
+
+  <!-- CI reuses the same notes to set the GitHub release body:
+       dotnet msbuild ... -t:ExportPackageReleaseNotes -p:ReleaseNotesExportPath=<file> -->
+  <Target Name="ExportPackageReleaseNotes" DependsOnTargets="PreparePackageReleaseNotesFromFile"
+          Condition="'$(ReleaseNotesExportPath)' != ''">
+    <WriteLinesToFile File="$(ReleaseNotesExportPath)" Lines="$(PackageReleaseNotes)"
+                      Overwrite="true" WriteOnlyWhenDifferent="true" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
Make assets/RELEASE-NOTES.txt the single source of truth for release notes:

- csproj: read the file verbatim and publish only the top version section into PackageReleaseNotes (regex-extract up to the first horizontal rule, strip the version header), preserving blank lines and wrapped-bullet indentation that ReadLinesFromFile mangled. Add an ExportPackageReleaseNotes target so CI can reuse the same notes.
- build-deploy: replace the step that overwrote RELEASE-NOTES.txt with the GitHub release body by one that syncs the release body from the file via ExportPackageReleaseNotes + gh release edit. Fix the workflow name, add least-privilege permissions and concurrency, pin actions to commit SHAs, pass secrets through env, and run on ubuntu-latest.
- test: add permissions and concurrency, pin actions to commit SHAs, run on ubuntu-latest, and drop the duplicated setup-dotnet step.

