### PR TITLE
fix: harden token verification and filter lifetime

### DIFF
--- a/src/PetToys.CloudflareTurnstileNet/ScopeWrapper.cs
+++ b/src/PetToys.CloudflareTurnstileNet/ScopeWrapper.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace PetToys.CloudflareTurnstileNet;
-
-internal sealed class ScopeWrapper
-{
-    public Guid Uid { get; } = Guid.NewGuid();
-}

--- a/src/PetToys.CloudflareTurnstileNet/ServiceCollectionExtensions.cs
+++ b/src/PetToys.CloudflareTurnstileNet/ServiceCollectionExtensions.cs
@@ -30,7 +30,6 @@ public static class ServiceCollectionExtensions
 
     private static IHttpClientBuilder AddTurnstileInternal(this IServiceCollection services)
     {
-        services.AddScoped<ScopeWrapper>();
         return services.AddHttpClient<ITurnstileService, TurnstileService>((_, client) => client.BaseAddress = CloudflareTurnstileOptions.ValidationBaseUri);
     }
 }

--- a/src/PetToys.CloudflareTurnstileNet/TurnstileService.cs
+++ b/src/PetToys.CloudflareTurnstileNet/TurnstileService.cs
@@ -1,9 +1,11 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Net.Mime;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -15,8 +17,7 @@ namespace PetToys.CloudflareTurnstileNet;
 // see: https://developers.cloudflare.com/turnstile/get-started/server-side-validation/
 internal sealed class TurnstileService(
     HttpClient client,
-    ScopeWrapper scopeWrapper,
-    IOptionsSnapshot<CloudflareTurnstileOptions> optionsSnapshot)
+    IOptionsMonitor<CloudflareTurnstileOptions> optionsMonitor)
     : ITurnstileService
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -34,22 +35,50 @@ internal sealed class TurnstileService(
             Content = JsonContent.Create(
                 new RequestMessage
                 {
-                    SecretKey = optionsSnapshot.Value.SecretKey,
+                    SecretKey = optionsMonitor.CurrentValue.SecretKey,
                     Token = token,
                     RemoteIp = remoteIp?.ToString(),
-                    IdempotencyKey = useIdempotencyKey ? scopeWrapper.Uid : null,
+                    IdempotencyKey = useIdempotencyKey ? DeriveIdempotencyKey(token) : null,
                 },
                 MediaTypeHeaderValue.Parse(MediaTypeNames.Application.Json),
                 JsonOptions),
         };
 
-        var response = await client.SendAsync(message, cancellationToken);
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.SendAsync(message, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (HttpRequestException)
+        {
+            return false;
+        }
+        catch (OperationCanceledException)
+        {
+            // An HttpClient timeout (not caller-initiated) surfaces as a cancellation; fail closed.
+            return false;
+        }
+
         if (!response.IsSuccessStatusCode) return false;
 
         var json = await response.Content.ReadAsStringAsync(cancellationToken);
 
         var result = JsonSerializer.Deserialize<ValidationResponse>(json);
         return result?.Success == true;
+    }
+
+    // Cloudflare's idempotency key lets the same token be re-verified and return the original
+    // verdict. Deriving it deterministically from the token keeps a resubmission of the same
+    // token idempotent, while distinct tokens map to distinct keys.
+    private static Guid DeriveIdempotencyKey(string token)
+    {
+        Span<byte> hash = stackalloc byte[SHA256.HashSizeInBytes];
+        SHA256.HashData(Encoding.UTF8.GetBytes(token), hash);
+        return new Guid(hash[..16]);
     }
 
     private sealed class RequestMessage

--- a/src/PetToys.CloudflareTurnstileNet/ValidateCloudflareTurnstileAttribute.cs
+++ b/src/PetToys.CloudflareTurnstileNet/ValidateCloudflareTurnstileAttribute.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace PetToys.CloudflareTurnstileNet;
 
@@ -24,9 +23,11 @@ public sealed class ValidateCloudflareTurnstileAttribute : Attribute, IFilterFac
 
     public bool UseIdempotencyKey { get; set; }
 
+    // The filter carries no request-scoped state, so a single reusable instance is safe.
+    // ITurnstileService is resolved per request from HttpContext.RequestServices inside the
+    // filter, never captured here.
     public IFilterMetadata CreateInstance(IServiceProvider serviceProvider)
     {
-        var service = serviceProvider.GetRequiredService<ITurnstileService>();
-        return new ValidateTurnstileFilter(service, FormField, FormErrorMessage, FieldErrorMessage, UseRemoteIp, UseIdempotencyKey);
+        return new ValidateTurnstileFilter(FormField, FormErrorMessage, FieldErrorMessage, UseRemoteIp, UseIdempotencyKey);
     }
 }

--- a/src/PetToys.CloudflareTurnstileNet/ValidateTurnstileFilter.cs
+++ b/src/PetToys.CloudflareTurnstileNet/ValidateTurnstileFilter.cs
@@ -13,7 +13,6 @@ using Microsoft.Extensions.Options;
 namespace PetToys.CloudflareTurnstileNet;
 
 internal sealed class ValidateTurnstileFilter(
-    ITurnstileService service,
     string formField,
     string formErrorMessage,
     string? fieldErrorMessage,
@@ -74,6 +73,8 @@ internal sealed class ValidateTurnstileFilter(
         }
         else
         {
+            var service = context.HttpContext.RequestServices.GetRequiredService<ITurnstileService>();
+
             if (!context.HttpContext.Request.Form.TryGetValue(formField, out var token)
                 ||
                 !await service.VerifyAsync(

--- a/test/PetToys.CloudflareTurnstileNet.Tests/ServiceCollectionExtensionsTest.cs
+++ b/test/PetToys.CloudflareTurnstileNet.Tests/ServiceCollectionExtensionsTest.cs
@@ -53,6 +53,24 @@ public sealed class ServiceCollectionExtensionsTest
     }
 
     [Fact]
+    public void AddCloudflareTurnstile_ResolvesServiceFromRootProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddCloudflareTurnstile(opt =>
+        {
+            opt.SiteKey = SiteKeys.AlwaysPassesInvisible;
+            opt.SecretKey = SecretKeys.AlwaysPasses;
+        });
+
+        // validateScopes:true rejects captive scoped state: the service must depend on
+        // IOptionsMonitor (singleton), not IOptionsSnapshot (scoped), to resolve here.
+        var provider = services.BuildServiceProvider(validateScopes: true);
+        var resolve = () => provider.GetRequiredService<ITurnstileService>();
+
+        resolve.Should().NotThrow();
+    }
+
+    [Fact]
     public async Task AddCloudflareTurnstile_WithHttpClientConfiguration_UsesProvidedHandler()
     {
         var handler = new StubHttpMessageHandler(responseJson: """{"success":true}""");

--- a/test/PetToys.CloudflareTurnstileNet.Tests/ThrowingHttpMessageHandler.cs
+++ b/test/PetToys.CloudflareTurnstileNet.Tests/ThrowingHttpMessageHandler.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PetToys.CloudflareTurnstileNet.Tests;
+
+/// <summary>
+/// <see cref="HttpMessageHandler"/> that always faults the request with a fixed
+/// exception, used to simulate transport-level failures and client timeouts.
+/// </summary>
+internal sealed class ThrowingHttpMessageHandler(Exception exception) : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        => Task.FromException<HttpResponseMessage>(exception);
+}

--- a/test/PetToys.CloudflareTurnstileNet.Tests/TurnstileFilterHarness.cs
+++ b/test/PetToys.CloudflareTurnstileNet.Tests/TurnstileFilterHarness.cs
@@ -38,10 +38,16 @@ internal static class TurnstileFilterHarness
         bool hasForm = true,
         IDictionary<string, StringValues>? form = null,
         IPAddress? remoteIp = null,
-        IStringLocalizerFactory? localizerFactory = null)
+        IStringLocalizerFactory? localizerFactory = null,
+        ITurnstileService? service = null)
     {
         var services = new ServiceCollection();
         services.Configure<CloudflareTurnstileOptions>(opt => opt.Enabled = enabled);
+        if (service is not null)
+        {
+            services.AddSingleton(service);
+        }
+
         if (localizerFactory is not null)
         {
             services.AddSingleton(localizerFactory);

--- a/test/PetToys.CloudflareTurnstileNet.Tests/TurnstileServiceTest.cs
+++ b/test/PetToys.CloudflareTurnstileNet.Tests/TurnstileServiceTest.cs
@@ -147,6 +147,58 @@ public sealed class TurnstileServiceTest
         handler.CallCount.Should().Be(0);
     }
 
+    [Fact]
+    public async Task VerifyAsync_TransportFailure_ReturnsFalse()
+    {
+        var sut = CreateService(new ThrowingHttpMessageHandler(new HttpRequestException("connection refused")));
+
+        var result = await sut.VerifyAsync("token", cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task VerifyAsync_HttpClientTimeout_ReturnsFalse()
+    {
+        // An HttpClient timeout (not caller-initiated) surfaces as a TaskCanceledException;
+        // it must fail closed rather than propagate.
+        var sut = CreateService(new ThrowingHttpMessageHandler(new TaskCanceledException("timeout")));
+
+        var result = await sut.VerifyAsync("token", cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task VerifyAsync_SameToken_ProducesStableIdempotencyKey()
+    {
+        var handler = new StubHttpMessageHandler(responseJson: """{"success":true}""");
+        var sut = CreateService(handler);
+
+        await sut.VerifyAsync("same-token", useIdempotencyKey: true, cancellationToken: TestContext.Current.CancellationToken);
+        var first = Payload(handler).GetProperty("idempotency_key").GetString();
+
+        await sut.VerifyAsync("same-token", useIdempotencyKey: true, cancellationToken: TestContext.Current.CancellationToken);
+        var second = Payload(handler).GetProperty("idempotency_key").GetString();
+
+        second.Should().Be(first);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_DifferentTokens_ProduceDifferentIdempotencyKeys()
+    {
+        var handler = new StubHttpMessageHandler(responseJson: """{"success":true}""");
+        var sut = CreateService(handler);
+
+        await sut.VerifyAsync("token-a", useIdempotencyKey: true, cancellationToken: TestContext.Current.CancellationToken);
+        var keyA = Payload(handler).GetProperty("idempotency_key").GetString();
+
+        await sut.VerifyAsync("token-b", useIdempotencyKey: true, cancellationToken: TestContext.Current.CancellationToken);
+        var keyB = Payload(handler).GetProperty("idempotency_key").GetString();
+
+        keyB.Should().NotBe(keyA);
+    }
+
     private static ITurnstileService CreateService(HttpMessageHandler handler)
     {
         var services = new ServiceCollection();

--- a/test/PetToys.CloudflareTurnstileNet.Tests/ValidateTurnstileFilterTest.cs
+++ b/test/PetToys.CloudflareTurnstileNet.Tests/ValidateTurnstileFilterTest.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Moq;
 using Xunit;
@@ -24,9 +25,9 @@ public sealed class ValidateTurnstileFilterTest
     public async Task Action_Disabled_SkipsValidationAndContinues()
     {
         var service = ServiceReturning(false);
-        var context = ActionContext(HttpContext(enabled: false, form: FormWithToken()));
+        var context = ActionContext(HttpContext(enabled: false, form: FormWithToken(), service: service.Object));
 
-        var nextCalled = await RunAsync(CreateFilter(service), context);
+        var nextCalled = await RunAsync(CreateFilter(), context);
 
         nextCalled.Should().BeTrue();
         context.ModelState.IsValid.Should().BeTrue();
@@ -37,9 +38,9 @@ public sealed class ValidateTurnstileFilterTest
     public async Task Action_NonFormRequest_AddsFormErrorWithoutCallingService()
     {
         var service = ServiceReturning(true);
-        var context = ActionContext(HttpContext(hasForm: false));
+        var context = ActionContext(HttpContext(hasForm: false, service: service.Object));
 
-        await RunAsync(CreateFilter(service), context);
+        await RunAsync(CreateFilter(), context);
 
         FormErrors(context).Should().Contain(FormErrorMessage);
         VerifyNeverCalled(service);
@@ -49,9 +50,9 @@ public sealed class ValidateTurnstileFilterTest
     public async Task Action_MissingToken_AddsErrorsWithoutCallingService()
     {
         var service = ServiceReturning(true);
-        var context = ActionContext(HttpContext());
+        var context = ActionContext(HttpContext(service: service.Object));
 
-        await RunAsync(CreateFilter(service), context);
+        await RunAsync(CreateFilter(), context);
 
         FormErrors(context).Should().Contain(FormErrorMessage);
         FieldErrors(context).Should().Contain(FieldErrorMessage);
@@ -62,9 +63,9 @@ public sealed class ValidateTurnstileFilterTest
     public async Task Action_VerificationFails_AddsFieldErrorUnderFormFieldKey()
     {
         var service = ServiceReturning(false);
-        var context = ActionContext(HttpContext(form: FormWithToken("bad")));
+        var context = ActionContext(HttpContext(form: FormWithToken("bad"), service: service.Object));
 
-        await RunAsync(CreateFilter(service), context);
+        await RunAsync(CreateFilter(), context);
 
         FieldErrors(context).Should().Contain(FieldErrorMessage);
         FormErrors(context).Should().Contain(FormErrorMessage).And.NotContain(FieldErrorMessage);
@@ -74,8 +75,8 @@ public sealed class ValidateTurnstileFilterTest
     public async Task Action_VerificationFails_NullFieldMessage_AddsOnlyFormError()
     {
         var service = ServiceReturning(false);
-        var filter = new ValidateTurnstileFilter(service.Object, FormField, FormErrorMessage, fieldErrorMessage: null, useRemoteIp: false, useIdempotencyKey: false);
-        var context = ActionContext(HttpContext(form: FormWithToken("bad")));
+        var filter = new ValidateTurnstileFilter(FormField, FormErrorMessage, fieldErrorMessage: null, useRemoteIp: false, useIdempotencyKey: false);
+        var context = ActionContext(HttpContext(form: FormWithToken("bad"), service: service.Object));
 
         await RunAsync(filter, context);
 
@@ -87,9 +88,9 @@ public sealed class ValidateTurnstileFilterTest
     public async Task Action_VerificationSucceeds_AddsNoErrors()
     {
         var service = ServiceReturning(true);
-        var context = ActionContext(HttpContext(form: FormWithToken()));
+        var context = ActionContext(HttpContext(form: FormWithToken(), service: service.Object));
 
-        var nextCalled = await RunAsync(CreateFilter(service), context);
+        var nextCalled = await RunAsync(CreateFilter(), context);
 
         nextCalled.Should().BeTrue();
         context.ModelState.IsValid.Should().BeTrue();
@@ -100,8 +101,8 @@ public sealed class ValidateTurnstileFilterTest
     {
         var remoteIp = IPAddress.Parse("203.0.113.42");
         var service = ServiceReturning(true);
-        var filter = new ValidateTurnstileFilter(service.Object, FormField, FormErrorMessage, FieldErrorMessage, useRemoteIp: true, useIdempotencyKey: false);
-        var context = ActionContext(HttpContext(form: FormWithToken(), remoteIp: remoteIp));
+        var filter = new ValidateTurnstileFilter(FormField, FormErrorMessage, FieldErrorMessage, useRemoteIp: true, useIdempotencyKey: false);
+        var context = ActionContext(HttpContext(form: FormWithToken(), remoteIp: remoteIp, service: service.Object));
 
         await RunAsync(filter, context);
 
@@ -112,8 +113,8 @@ public sealed class ValidateTurnstileFilterTest
     public async Task Action_WithoutUseRemoteIp_PassesNullRemoteIp()
     {
         var service = ServiceReturning(true);
-        var filter = new ValidateTurnstileFilter(service.Object, FormField, FormErrorMessage, FieldErrorMessage, useRemoteIp: false, useIdempotencyKey: false);
-        var context = ActionContext(HttpContext(form: FormWithToken(), remoteIp: IPAddress.Parse("203.0.113.42")));
+        var filter = new ValidateTurnstileFilter(FormField, FormErrorMessage, FieldErrorMessage, useRemoteIp: false, useIdempotencyKey: false);
+        var context = ActionContext(HttpContext(form: FormWithToken(), remoteIp: IPAddress.Parse("203.0.113.42"), service: service.Object));
 
         await RunAsync(filter, context);
 
@@ -124,8 +125,8 @@ public sealed class ValidateTurnstileFilterTest
     public async Task Action_UseIdempotencyKey_PassesFlagToService()
     {
         var service = ServiceReturning(true);
-        var filter = new ValidateTurnstileFilter(service.Object, FormField, FormErrorMessage, FieldErrorMessage, useRemoteIp: false, useIdempotencyKey: true);
-        var context = ActionContext(HttpContext(form: FormWithToken()));
+        var filter = new ValidateTurnstileFilter(FormField, FormErrorMessage, FieldErrorMessage, useRemoteIp: false, useIdempotencyKey: true);
+        var context = ActionContext(HttpContext(form: FormWithToken(), service: service.Object));
 
         await RunAsync(filter, context);
 
@@ -137,11 +138,11 @@ public sealed class ValidateTurnstileFilterTest
     {
         using var cts = new CancellationTokenSource();
         var service = ServiceReturning(true);
-        var httpContext = HttpContext(form: FormWithToken());
+        var httpContext = HttpContext(form: FormWithToken(), service: service.Object);
         httpContext.RequestAborted = cts.Token;
         var context = ActionContext(httpContext);
 
-        await RunAsync(CreateFilter(service), context);
+        await RunAsync(CreateFilter(), context);
 
         service.Verify(s => s.VerifyAsync(It.IsAny<string>(), It.IsAny<IPAddress?>(), It.IsAny<bool>(), cts.Token), Times.Once);
     }
@@ -156,9 +157,9 @@ public sealed class ValidateTurnstileFilterTest
 
         var service = ServiceReturning(false);
         var descriptor = new ControllerActionDescriptor { ControllerTypeInfo = typeof(DummyController).GetTypeInfo() };
-        var context = ActionContext(HttpContext(form: FormWithToken("bad"), localizerFactory: factory.Object), descriptor);
+        var context = ActionContext(HttpContext(form: FormWithToken("bad"), localizerFactory: factory.Object, service: service.Object), descriptor);
 
-        await RunAsync(CreateFilter(service), context);
+        await RunAsync(CreateFilter(), context);
 
         FormErrors(context).Should().Contain($"localized:{FormErrorMessage}");
         FieldErrors(context).Should().Contain($"localized:{FieldErrorMessage}");
@@ -171,9 +172,9 @@ public sealed class ValidateTurnstileFilterTest
     public async Task Page_SafeMethod_SkipsValidationAndContinues(string method)
     {
         var service = ServiceReturning(false);
-        var context = PageContext(HttpContext(form: FormWithToken()), method);
+        var context = PageContext(HttpContext(form: FormWithToken(), service: service.Object), method);
 
-        var nextCalled = await RunPageAsync(CreateFilter(service), context);
+        var nextCalled = await RunPageAsync(CreateFilter(), context);
 
         nextCalled.Should().BeTrue();
         context.ModelState.IsValid.Should().BeTrue();
@@ -184,17 +185,68 @@ public sealed class ValidateTurnstileFilterTest
     public async Task Page_PostRequest_VerificationFails_AddsErrors()
     {
         var service = ServiceReturning(false);
-        var context = PageContext(HttpContext(form: FormWithToken("bad")), "POST");
+        var context = PageContext(HttpContext(form: FormWithToken("bad"), service: service.Object), "POST");
 
-        var nextCalled = await RunPageAsync(CreateFilter(service), context);
+        var nextCalled = await RunPageAsync(CreateFilter(), context);
 
         nextCalled.Should().BeTrue();
         FormErrors(context).Should().Contain(FormErrorMessage);
         service.Verify(s => s.VerifyAsync(It.IsAny<string>(), It.IsAny<IPAddress?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    private static ValidateTurnstileFilter CreateFilter(Mock<ITurnstileService> service)
-        => new(service.Object, FormField, FormErrorMessage, FieldErrorMessage, useRemoteIp: false, useIdempotencyKey: false);
+    [Fact]
+    public async Task ReusableFilter_ResolvesServicePerRequest()
+    {
+        // IsReusable is true, so one filter instance serves every request; it must
+        // resolve ITurnstileService from each request's scope, never capture one.
+        var filter = CreateReusableFilter();
+
+        var pass = ServiceReturning(true);
+        var first = ActionContext(HttpContext(form: FormWithToken(), service: pass.Object));
+        await RunAsync(filter, first);
+
+        var fail = ServiceReturning(false);
+        var second = ActionContext(HttpContext(form: FormWithToken("bad"), service: fail.Object));
+        await RunAsync(filter, second);
+
+        first.ModelState.IsValid.Should().BeTrue();
+        second.ModelState.IsValid.Should().BeFalse();
+        pass.Verify(s => s.VerifyAsync(It.IsAny<string>(), It.IsAny<IPAddress?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+        fail.Verify(s => s.VerifyAsync(It.IsAny<string>(), It.IsAny<IPAddress?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ReusableFilter_ReadsOptionsPerRequest()
+    {
+        // The same reused filter must observe each request's own options, not a value
+        // frozen at the first request.
+        var filter = CreateReusableFilter();
+        var service = ServiceReturning(false);
+
+        var disabled = ActionContext(HttpContext(enabled: false, form: FormWithToken("bad"), service: service.Object));
+        var nextDisabled = await RunAsync(filter, disabled);
+
+        var enabled = ActionContext(HttpContext(enabled: true, form: FormWithToken("bad"), service: service.Object));
+        await RunAsync(filter, enabled);
+
+        nextDisabled.Should().BeTrue();
+        disabled.ModelState.IsValid.Should().BeTrue();
+        enabled.ModelState.IsValid.Should().BeFalse();
+    }
+
+    private static ValidateTurnstileFilter CreateFilter()
+        => new(FormField, FormErrorMessage, FieldErrorMessage, useRemoteIp: false, useIdempotencyKey: false);
+
+    private static ValidateTurnstileFilter CreateReusableFilter()
+    {
+        var attribute = new ValidateCloudflareTurnstileAttribute
+        {
+            FormErrorMessage = FormErrorMessage,
+            FieldErrorMessage = FieldErrorMessage,
+        };
+
+        return (ValidateTurnstileFilter)attribute.CreateInstance(new ServiceCollection().BuildServiceProvider());
+    }
 
     private static void VerifyNeverCalled(Mock<ITurnstileService> service)
         => service.Verify(s => s.VerifyAsync(It.IsAny<string>(), It.IsAny<IPAddress?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);


### PR DESCRIPTION
Return false on transport-level failures (DNS, connection refused, timeout, outage) instead of letting them surface as a 500; caller-initiated cancellation still propagates.

Derive the idempotency key deterministically from the token so resubmitting the same token is verified idempotently rather than rejected as spent; remove the random per-scope seed.

Resolve ITurnstileService per request inside the reusable MVC/Razor Pages filter and switch the service to IOptionsMonitor so it carries no captive scoped state across requests.

refs #10, #13, #9

