### PR TITLE
build: hand NuGet updates over to Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,15 +11,3 @@ updates:
       actions:
         patterns:
           - "*"
-
-  - package-ecosystem: "nuget"
-    directory: "/"
-    target-branch: "dev"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "build"
-    groups:
-      nuget:
-        patterns:
-          - "*"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "enabledManagers": [
+    "nuget"
+  ],
+  "timezone": "UTC",
+  "schedule": [
+    "before 3am on saturday"
+  ],
+  "semanticCommits": "disabled",
+  "commitMessagePrefix": "build:",
+  "packageRules": [
+    {
+      "description": "Keep the NuGet version-range notation used in Directory.Packages.props ([x.y.z,) stays a range instead of collapsing to a bare version).",
+      "matchManagers": [
+        "nuget"
+      ],
+      "rangeStrategy": "bump",
+      "groupName": "nuget"
+    }
+  ]
+}


### PR DESCRIPTION
Dependabot's NuGet updater collapses version ranges to bare versions when it writes an update back. That changes the dependency ranges emitted into the published nuspec and required a fix-up commit on every PR.

Renovate with rangeStrategy "bump" moves the lower bound and keeps the range notation, including the upper bound on two-sided ranges. Dependabot keeps handling github-actions only.
