### PR TITLE
build: bump NuGet dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,15 +6,15 @@
     <FrameworkExtVersion Condition="'$(TargetFramework)' == 'net8.0'">[8.0.0,11.0.0)</FrameworkExtVersion>
     <FrameworkExtVersion Condition="'$(TargetFramework)' == 'net9.0'">[9.0.0,11.0.0)</FrameworkExtVersion>
     <FrameworkExtVersion Condition="'$(TargetFramework)' == 'net10.0'">[10.0.0,11.0.0)</FrameworkExtVersion>
-    <RoslinatorVersion>[4.15.0,)</RoslinatorVersion>
+    <RoslynatorVersion>[4.16.0,)</RoslynatorVersion>
   </PropertyGroup>
   <ItemGroup>
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="Roslynator.Analyzers" Version="$(RoslinatorVersion)" />
-    <GlobalPackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="$(RoslinatorVersion)" />
-    <GlobalPackageReference Include="Roslynator.CodeFixes" Version="$(RoslinatorVersion)" />
-    <GlobalPackageReference Include="Roslynator.Formatting.Analyzers" Version="$(RoslinatorVersion)" />
-    <GlobalPackageReference Include="Roslynator.Refactorings" Version="$(RoslinatorVersion)" />
+    <GlobalPackageReference Include="Roslynator.Analyzers" Version="$(RoslynatorVersion)" />
+    <GlobalPackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="$(RoslynatorVersion)" />
+    <GlobalPackageReference Include="Roslynator.CodeFixes" Version="$(RoslynatorVersion)" />
+    <GlobalPackageReference Include="Roslynator.Formatting.Analyzers" Version="$(RoslynatorVersion)" />
+    <GlobalPackageReference Include="Roslynator.Refactorings" Version="$(RoslynatorVersion)" />
   </ItemGroup>
 </Project>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -2,10 +2,10 @@
   <!--<Version>1.0</Version>-->
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
   <ItemGroup>
-    <PackageVersion Include="AwesomeAssertions" Version="[9.4.0,)" />
+    <PackageVersion Include="AwesomeAssertions" Version="[9.5.0,)" />
     <PackageVersion Include="Bogus" Version="[35.6.3,)" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="[9.4.0,)" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[18.7.0,)" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[18.8.1,)" />
     <PackageVersion Include="Moq" Version="[4.20.72,)" />
     <PackageVersion Include="xunit.v3" Version="[3.2.2,)" />
   </ItemGroup>


### PR DESCRIPTION
## Changes

- `AwesomeAssertions` 9.4.0 -> 9.5.0
- `Microsoft.NET.Test.Sdk` 18.7.0 -> 18.8.1
- `Roslynator.*` 4.15.0 -> 4.16.0
- Renamed the MSBuild property `RoslinatorVersion` -> `RoslynatorVersion` (typo, now matches the package name)

## Verification

- `dotnet restore --force` — resolves 4.16.0 / 9.5.0 / 18.8.1
- `dotnet build -warnaserror` — 0 warnings, 0 errors
- `dotnet test` — 42/42 passed on net8.0, net9.0, net10.0