### PR TITLE
ci: publish to nuget.org through trusted publishing

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -117,6 +117,9 @@ jobs:
     if: |
       github.event.repository.fork == false &&
       github.event.release.prerelease == false
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
     - name: Download artifacts
@@ -129,9 +132,15 @@ jobs:
       with:
         global-json-file: global.json
 
+    - name: NuGet login
+      id: login
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Push to nuget.org
       working-directory: ${{ env.PackagesSubfolder }}
       env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
       run: |
         dotnet nuget push "*.nupkg" -k "$NUGET_API_KEY" -s ${{ env.NuGetOrgPackageSource }} --skip-duplicate

--- a/assets/RELEASE-NOTES.txt
+++ b/assets/RELEASE-NOTES.txt
@@ -1,3 +1,12 @@
+10.1.3
+======
+
+Changed:
+- Packages are now published to NuGet.org through trusted publishing, so the
+  release pipeline no longer depends on a long-lived API key.
+
+----------
+
 10.1.2
 ======
 


### PR DESCRIPTION
## Summary

Switches the nuget.org push to trusted publishing, matching [db-assistant-mssql#30](https://github.com/pet-toys/db-assistant-mssql/pull/30), which is already released and verified end to end. The `deploy-nuget` job exchanges the GitHub OIDC token for a short-lived API key instead of reading a long-lived one from the `production` environment.

- `id-token: write` added to `deploy-nuget` so GitHub issues the OIDC token. Job-level `permissions` replace the inherited set, so `contents: read` is restated for the artifact download.
- `NuGet/login` pinned by commit SHA, like every other action in the workflow.
- The short-lived key is passed through `env:` rather than the command line, matching the GitHub Packages push step.
- `NUGET_USER` holds the username of the account that created the trusted publishing policy, which is what the token exchange endpoint looks up. The policy is owned by the `pet-toys` organization, so package ownership is unchanged.

Release notes get a `10.1.3` section, since the change is only visible to consumers as a supply-chain property of the package.

**Requires before merge:** a trusted publishing policy for this repository on nuget.org (policies are per-repository) and the `NUGET_USER` secret in the `production` environment. Note that a prerelease tag will not exercise this path - `deploy-nuget` only runs for non-prerelease releases.

## Related issue

n/a - infrastructure change.

## Checklist

- [x] Targets the `dev` branch.
- [x] `dotnet build -c Release` passes (warnings are treated as errors).
- [x] `dotnet test` passes across the supported target frameworks.
- [x] New behavior is covered by tests. - n/a, no product code changed. The release notes export target was verified by running `dotnet msbuild -t:ExportPackageReleaseNotes`.
- [x] Follows the [contributing guidelines](https://github.com/pet-toys/cloudflare-turnstile-net/blob/dev/docs/CONTRIBUTING.md).
